### PR TITLE
load the image when the slide is active

### DIFF
--- a/src/fitted-image/fitted-image.html
+++ b/src/fitted-image/fitted-image.html
@@ -1,10 +1,12 @@
 <div class="fitted-image">
   <ion-spinner [hidden]="!loading"></ion-spinner>
   <img
-    [src]="photo.url"
+    [src]="photoUrl"
     [ngStyle]="imageStyle"
     (load)="imageLoad($event)"
     [hidden]="loading"
     alt=""
   />
+
+
 </div>

--- a/src/fitted-image/fitted-image.html
+++ b/src/fitted-image/fitted-image.html
@@ -1,6 +1,6 @@
 <div class="fitted-image">
   <ion-spinner [hidden]="!loading"></ion-spinner>
-  <img
+  <img *ngIf="photoUrl"
     [src]="photoUrl"
     [ngStyle]="imageStyle"
     (load)="imageLoad($event)"

--- a/src/fitted-image/fitted-image.scss
+++ b/src/fitted-image/fitted-image.scss
@@ -3,7 +3,7 @@
 
   .fitted-image {
     display: inline-block;
-    position: relative;
+    //position: relative;
 
     transform-origin: left top;
 
@@ -19,6 +19,8 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
+      width:100px;
+      height:100px;
     }
 
     img {

--- a/src/gallery-modal/gallery-modal.html
+++ b/src/gallery-modal/gallery-modal.html
@@ -12,6 +12,7 @@
   <div class="image-on-top" [hidden]="sliderLoaded">
     <zoomable-image
       [photo]="initialImage"
+      [tokenObj]="tokenObj"
       [resizeTriggerer]="resizeTriggerer"
       [wrapperWidth]="width"
       [wrapperHeight]="height"
@@ -35,6 +36,7 @@
     <ion-slide *ngFor="let photo of photos; let i=index;">
       <zoomable-image
         [photo]="photo"
+        [tokenObj]="tokenObj"
         [picIndex]="i"
         [visibleSlide]="visibleSlide"
         [resizeTriggerer]="resizeTriggerer"

--- a/src/gallery-modal/gallery-modal.html
+++ b/src/gallery-modal/gallery-modal.html
@@ -26,14 +26,17 @@
     [ngStyle]="slidesStyle"
     touch-events
     (ionSlideDrag)="slidesDrag($event)"
+    (ionSlideDidChange)="slideDidChange($event)"
     (panup)="panUpDownEvent($event)"
     (pandown)="panUpDownEvent($event)"
     (panend)="panEndEvent($event)"
     (pancancel)="panEndEvent($event)"
   >
-    <ion-slide *ngFor="let photo of photos;">
+    <ion-slide *ngFor="let photo of photos; let i=index;">
       <zoomable-image
         [photo]="photo"
+        [picIndex]="i"
+        [visibleSlide]="visibleSlide"
         [resizeTriggerer]="resizeTriggerer"
         [wrapperWidth]="width"
         [wrapperHeight]="height"

--- a/src/gallery-modal/gallery-modal.ts
+++ b/src/gallery-modal/gallery-modal.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild, OnInit, ElementRef } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 import { ViewController, NavParams, Slides, Platform } from 'ionic-angular';
 import { Photo } from '../interfaces/photo-interface';
+import { TokenObj } from '../interfaces/tokenObj-interface';
 import { Subject } from 'rxjs/Subject';
 
 @Component({
@@ -19,6 +20,7 @@ export class GalleryModal implements OnInit {
   private initialSlide: number = 0;
   private visibleSlide:number;  
   private currentSlide: number = 0;
+  private tokenObj:TokenObj;
   private sliderLoaded: boolean = false;
   private closeIcon: string = 'arrow-back';
   private resizeTriggerer: Subject<any> = new Subject();
@@ -46,7 +48,9 @@ export class GalleryModal implements OnInit {
     this.closeIcon = params.get('closeIcon') || 'arrow-back';
     this.initialSlide = params.get('initialSlide') || 0;
     this.visibleSlide=this.initialSlide;
+    this.tokenObj = params.get('auth_token') || null;
     this.initialImage = this.photos[this.initialSlide] || {};
+    
   }
 
   public ngOnInit() {
@@ -123,8 +127,7 @@ export class GalleryModal implements OnInit {
     this.slidesDragging = true;
   }
 
-  private slideDidChange(event) {
-    console.log("tobbi ",event);
+  private slideDidChange(event) {    
     this.visibleSlide=event._activeIndex;
   }
 

--- a/src/gallery-modal/gallery-modal.ts
+++ b/src/gallery-modal/gallery-modal.ts
@@ -17,6 +17,7 @@ export class GalleryModal implements OnInit {
   public photos: Photo[];
   private sliderDisabled: boolean = false;
   private initialSlide: number = 0;
+  private visibleSlide:number;  
   private currentSlide: number = 0;
   private sliderLoaded: boolean = false;
   private closeIcon: string = 'arrow-back';
@@ -39,11 +40,12 @@ export class GalleryModal implements OnInit {
   private transitionDuration: string = '200ms';
   private transitionTimingFunction: string = 'cubic-bezier(0.33, 0.66, 0.66, 1)';
 
+
   constructor(private viewCtrl: ViewController, params: NavParams, private element: ElementRef, private platform: Platform, private domSanitizer: DomSanitizer) {
     this.photos = params.get('photos') || [];
     this.closeIcon = params.get('closeIcon') || 'arrow-back';
     this.initialSlide = params.get('initialSlide') || 0;
-
+    this.visibleSlide=this.initialSlide;
     this.initialImage = this.photos[this.initialSlide] || {};
   }
 
@@ -119,6 +121,11 @@ export class GalleryModal implements OnInit {
    */
   private slidesDrag(event) {
     this.slidesDragging = true;
+  }
+
+  private slideDidChange(event) {
+    console.log("tobbi ",event);
+    this.visibleSlide=event._activeIndex;
   }
 
   /**

--- a/src/interfaces/tokenObj-interface.ts
+++ b/src/interfaces/tokenObj-interface.ts
@@ -1,0 +1,4 @@
+export interface TokenObj {
+    header: string;
+    token: string;
+}

--- a/src/zoomable-image/zoomable-image.html
+++ b/src/zoomable-image/zoomable-image.html
@@ -9,9 +9,10 @@
     (onpan)="panEvent($event)"
     [ngStyle]="containerStyle"
   >
-  <p> mi toldo  dal cazzo {{canShow}} </p>
+  
     <fitted-image *ngIf="canShow"
       [photo]="photo"
+      [tokenObj]="tokenObj"
       [ngStyle]="imageStyle"
       [resizeTriggerer]="resizeTriggerer"
       [wrapperWidth]="wrapperWidth"

--- a/src/zoomable-image/zoomable-image.html
+++ b/src/zoomable-image/zoomable-image.html
@@ -9,7 +9,8 @@
     (onpan)="panEvent($event)"
     [ngStyle]="containerStyle"
   >
-    <fitted-image
+  <p> mi toldo  dal cazzo {{canShow}} </p>
+    <fitted-image *ngIf="canShow"
       [photo]="photo"
       [ngStyle]="imageStyle"
       [resizeTriggerer]="resizeTriggerer"

--- a/src/zoomable-image/zoomable-image.html
+++ b/src/zoomable-image/zoomable-image.html
@@ -9,7 +9,7 @@
     (onpan)="panEvent($event)"
     [ngStyle]="containerStyle"
   >
-  <p> mi toldo  dal cazzo {{canShow}} </p>
+ 
     <fitted-image *ngIf="canShow"
       [photo]="photo"
       [ngStyle]="imageStyle"

--- a/src/zoomable-image/zoomable-image.html
+++ b/src/zoomable-image/zoomable-image.html
@@ -9,12 +9,7 @@
     (onpan)="panEvent($event)"
     [ngStyle]="containerStyle"
   >
-<<<<<<< HEAD
-  
-=======
- 
->>>>>>> c3b91ba2e5b4e3959e1ec68ea469f0595af55681
-    <fitted-image *ngIf="canShow"
+  <fitted-image *ngIf="canShow"
       [photo]="photo"
       [tokenObj]="tokenObj"
       [ngStyle]="imageStyle"

--- a/src/zoomable-image/zoomable-image.ts
+++ b/src/zoomable-image/zoomable-image.ts
@@ -11,6 +11,16 @@ export class ZoomableImage implements OnInit, OnDestroy {
   @ViewChild('ionScrollContainer', { read: ElementRef }) ionScrollContainer: ElementRef;
 
   @Input() photo: any;
+  @Input()
+  set visibleSlide(visibleSlide: number) {      
+    this._visibleSlide = visibleSlide; 
+    
+    if (this.picIndex == this._visibleSlide)
+        this.canShow = true;
+
+  }
+
+  @Input() picIndex: number;
   @Input() resizeTriggerer: Subject<any>;
   @Input() wrapperWidth: number;
   @Input() wrapperHeight: number;
@@ -19,6 +29,8 @@ export class ZoomableImage implements OnInit, OnDestroy {
   @Output() enableScroll = new EventEmitter();
   @Output() zoomChange = new EventEmitter();
 
+  private _visibleSlide:number;
+  private canShow:boolean=false;
   private scrollableElement: any;
   private scrollListener: any;
 
@@ -76,6 +88,9 @@ export class ZoomableImage implements OnInit, OnDestroy {
     this.resizeSubscription = this.resizeTriggerer.subscribe(event => {
       this.resize(event);
     });
+
+    if (this.picIndex == this._visibleSlide)
+        this.canShow = true;
   }
 
   public ngOnDestroy() {

--- a/src/zoomable-image/zoomable-image.ts
+++ b/src/zoomable-image/zoomable-image.ts
@@ -1,3 +1,4 @@
+import { TokenObj } from '../interfaces/tokenObj-interface';
 import { Component, OnInit, OnDestroy, Input, Output, ViewChild, EventEmitter, ElementRef } from '@angular/core';
 import { ViewController, Scroll } from 'ionic-angular';
 import { Subject } from 'rxjs/Subject';
@@ -21,6 +22,7 @@ export class ZoomableImage implements OnInit, OnDestroy {
   }
 
   @Input() picIndex: number;
+  @Input() tokenObj: TokenObj;
   @Input() resizeTriggerer: Subject<any>;
   @Input() wrapperWidth: number;
   @Input() wrapperHeight: number;


### PR DESCRIPTION
This is a proposal for the issue #40

On a further update, in order to implement the preloading of the "next" picture, we can  use the ion-slide events ionSlidePrevEnd, ionSlideNextEnd instead of ionSlideDidChange.
In this way the code would know if to preload the slide+1 or slide-1 